### PR TITLE
Add word by word

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,7 @@ There are three main subsections of the program:
     - Continuously prints out the position of the cursor so you know where to tell it to click  
 2. Spam a whole message:  
     - Sends a whole message at a time at a specified interval  
-3. Spam letter by letter  
+3. Spam word by word:
+    - Sends the entire message word by word with a given delay for each iterartion
+4. Spam letter by letter  
     - Sends the entire message letter by letter, as fast as possible  

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,6 @@ use std::{env, io};
 
 use enigo::*;
 
-use crate::get_user_decisions::get_user_specs;
-
 mod get_user_decisions;
 mod show_screen_coords;
 
@@ -84,11 +82,17 @@ fn main() {
                 }
             }
             WhichMain::SpamWords => {
-                let specs = get_user_specs();
+                let specs = get_user_decisions::get_user_specs();
                 println!("{:?}", specs);
-                for _ in 0..specs.repeats{
-                    print_by_word(&specs);
-                    sleep(Duration::from_millis((specs.time_period*1000.0) as u64));
+                for _ in 0..specs.repeats {
+                    print_by_word(
+                        specs.message.as_str(),
+                        specs.browser_position.x,
+                        specs.browser_position.y,
+                        specs.whatsapp_position.x,
+                        specs.whatsapp_position.y,
+                    );
+                    sleep(Duration::from_millis((specs.time_period * 1000.0) as u64));
                 }
             }
         }
@@ -102,12 +106,14 @@ fn coords_run_or_exit() -> WhichMain {
     let choice: WhichMain;
 
     println!("Please select a run option: ");
-    println!("{}\n{}\n{}\n{}\n{}",
-             "Show screen coordinates: (c)",
-             "Spam a whole message at once (m)",
-             "Spam word by word (w)",
-             "Spam letter by letter (l)",
-             "Exit: (e)");
+    println!(
+        "{}\n{}\n{}\n{}\n{}",
+        "Show screen coordinates: (c)",
+        "Spam a whole message at once (m)",
+        "Spam word by word (w)",
+        "Spam letter by letter (l)",
+        "Exit: (e)"
+    );
 
     loop {
         match user_input.as_str() {
@@ -172,33 +178,28 @@ fn read_message_from_file(path: &Path) -> String {
 }
 
 fn print_by_word(
-    message: &str,
-    browser_x: i32,
-    browser_y: i32,
-    whatsapp_x: i32,
+    message: &str, 
+    browser_x: i32, 
+    browser_y: i32, 
+    whatsapp_x: i32, 
     whatsapp_y: i32,
-){
+    ) {
     let words = message.split_whitespace();
-    
+
     let mut enigo = Enigo::new();
     //Move to browser and click.
-    enigo.mouse_move_to(
-        browser_x,
-        browser_y);
+    enigo.mouse_move_to(browser_x, browser_y);
     enigo.mouse_click(MouseButton::Left);
 
     //Move mouse to whatsapp position.
-    enigo.mouse_move_to(
-        whatsapp_x,
-        whatsapp_y);
+    enigo.mouse_move_to(whatsapp_x, whatsapp_y);
     enigo.mouse_click(MouseButton::Left);
-    
+
     //Print each word
-    for word in words{
+    for word in words {
         enigo.key_sequence(word);
         enigo.key_click(Key::Return);
     }
-
 }
 
 fn print_by_character(

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ use std::{env, io};
 
 use enigo::*;
 
+use crate::get_user_decisions::get_user_specs;
+
 mod get_user_decisions;
 mod show_screen_coords;
 
@@ -41,6 +43,7 @@ fn main_old() {
 enum WhichMain {
     GetCoords,
     SpamWholeMessage,
+    SpamWords,
     SpamLetters,
     Exit,
 }
@@ -80,6 +83,14 @@ fn main() {
                     )
                 }
             }
+            WhichMain::SpamWords => {
+                let specs = get_user_specs();
+                println!("{:?}", specs);
+                for _ in 0..specs.repeats{
+                    print_by_word(&specs);
+                    sleep(Duration::from_millis((specs.time_period*1000.0) as u64));
+                }
+            }
         }
         user_choice = coords_run_or_exit();
     }
@@ -91,7 +102,12 @@ fn coords_run_or_exit() -> WhichMain {
     let choice: WhichMain;
 
     println!("Please select a run option: ");
-    println!("Show screen coordinates: (c)\nSpam a whole message at once (m)\nSpam letter by letter (l)\nExit: (e)");
+    println!("{}\n{}\n{}\n{}\n{}",
+             "Show screen coordinates: (c)",
+             "Spam a whole message at once (m)",
+             "Spam word by word (w)",
+             "Spam letter by letter (l)",
+             "Exit: (e)");
 
     loop {
         match user_input.as_str() {
@@ -101,6 +117,10 @@ fn coords_run_or_exit() -> WhichMain {
             }
             "m" => {
                 choice = WhichMain::SpamWholeMessage;
+                break;
+            }
+            "w" => {
+                choice = WhichMain::SpamWords;
                 break;
             }
             "l" => {
@@ -117,7 +137,7 @@ fn coords_run_or_exit() -> WhichMain {
 
         loop {
             user_input.clear();
-            print!("Your selection (c/m/l/e): ");
+            print!("Your selection (c/m/w/l/e): ");
             io::stdout().flush().unwrap();
             match stdin.read_line(&mut user_input) {
                 Ok(_) => {
@@ -149,6 +169,36 @@ fn read_message_from_file(path: &Path) -> String {
         Err(why) => panic!("Couldn't read {}: {}", display, why),
         Ok(_) => s,
     }
+}
+
+fn print_by_word(
+    message: &str,
+    browser_x: i32,
+    browser_y: i32,
+    whatsapp_x: i32,
+    whatsapp_y: i32,
+){
+    let words = message.split_whitespace();
+    
+    let mut enigo = Enigo::new();
+    //Move to browser and click.
+    enigo.mouse_move_to(
+        browser_x,
+        browser_y);
+    enigo.mouse_click(MouseButton::Left);
+
+    //Move mouse to whatsapp position.
+    enigo.mouse_move_to(
+        whatsapp_x,
+        whatsapp_y);
+    enigo.mouse_click(MouseButton::Left);
+    
+    //Print each word
+    for word in words{
+        enigo.key_sequence(word);
+        enigo.key_click(Key::Return);
+    }
+
 }
 
 fn print_by_character(


### PR DESCRIPTION
The art of spamming is one filled with compromises.
For how can we make sure WhatsApp doesn't receive our massages out of order, rending the spam-ee unable to comprehend the beauty of a letter by letter spam?!
Sending the whole message several times just doesn't invoke the same feeling as letter by letter, but the former guarantees full legibility unlike the latter. 

Therefore I propose a compromise between the two:
Word by word spamming.
The satisfaction of a screen filled with parts of messages but still relatively easier to parse in case of a message being receive out-of-order.


This pull request is dedicated to my two stupid cats who stepped on my keyboard several times while writing this pull request's code.
And while writing the pull request as well.


![image](https://github.com/robomarvin1501/WhatsAppSpamming/assets/34936527/4e079097-77ee-4cff-9b39-0ece82fc7266)
(For archival purposes)